### PR TITLE
Trying to avoid .NET 7 installation step

### DIFF
--- a/Src/WinFileExplorerGbxAddons.IconOverlay/GbxIconOverlay.cs
+++ b/Src/WinFileExplorerGbxAddons.IconOverlay/GbxIconOverlay.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Win32;
+using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace WinFileExplorerGbxAddons.IconOverlay;
@@ -31,7 +33,7 @@ public partial class GbxIconOverlay : IShellIconOverlayIdentifier
         return (int)HRESULT.S_OK;
     }
 
-    public int GetOverlayInfo(nint iconFileBuffer, int iconFileBufferSize, out int iconIndex, out uint flags)
+    public int GetOverlayInfo(IntPtr iconFileBuffer, int iconFileBufferSize, out int iconIndex, out uint flags)
     {
         var iconFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "BigBang1112", "WinFileExplorerGbxAddons", "IconOverlay", "Gbx.ico");
         var bytes = System.Text.Encoding.Unicode.GetBytes(iconFile);
@@ -59,13 +61,13 @@ public partial class GbxIconOverlay : IShellIconOverlayIdentifier
         var regKey = Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\ShellIconOverlayIdentifiers\" + t.Name);
         regKey.SetValue("", t.GUID.ToString("B"));
         regKey.Close();
-        ShellInterop.SHChangeNotify(0x08000000, 0, nint.Zero, nint.Zero);
+        ShellInterop.SHChangeNotify(0x08000000, 0, IntPtr.Zero, IntPtr.Zero);
     }
 
     [ComUnregisterFunction]
     public static void UnregisterFunction(Type t)
     {
         Registry.LocalMachine.DeleteSubKeyTree(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\ShellIconOverlayIdentifiers\" + t.Name);
-        ShellInterop.SHChangeNotify(0x08000000, 0, nint.Zero, nint.Zero);
+        ShellInterop.SHChangeNotify(0x08000000, 0, IntPtr.Zero, IntPtr.Zero);
     }
 }

--- a/Src/WinFileExplorerGbxAddons.IconOverlay/HFLAGS.cs
+++ b/Src/WinFileExplorerGbxAddons.IconOverlay/HFLAGS.cs
@@ -1,4 +1,6 @@
-﻿namespace WinFileExplorerGbxAddons.IconOverlay;
+﻿using System;
+
+namespace WinFileExplorerGbxAddons.IconOverlay;
 
 [Flags]
 public enum HFLAGS : uint

--- a/Src/WinFileExplorerGbxAddons.IconOverlay/HRESULT.cs
+++ b/Src/WinFileExplorerGbxAddons.IconOverlay/HRESULT.cs
@@ -1,4 +1,6 @@
-﻿namespace WinFileExplorerGbxAddons.IconOverlay;
+﻿using System;
+
+namespace WinFileExplorerGbxAddons.IconOverlay;
 
 [Flags]
 public enum HRESULT : uint

--- a/Src/WinFileExplorerGbxAddons.IconOverlay/ShellInterop.cs
+++ b/Src/WinFileExplorerGbxAddons.IconOverlay/ShellInterop.cs
@@ -8,6 +8,6 @@ public sealed partial class ShellInterop
     {
     }
 
-    [LibraryImport("shell32.dll")]
-    internal static partial void SHChangeNotify(int eventID, uint flags, nint item1, nint item2);
+    [DllImport("shell32.dll")]
+    internal static extern void SHChangeNotify(int eventID, uint flags, nint item1, nint item2);
 }

--- a/Src/WinFileExplorerGbxAddons.IconOverlay/WinFileExplorerGbxAddons.IconOverlay.csproj
+++ b/Src/WinFileExplorerGbxAddons.IconOverlay/WinFileExplorerGbxAddons.IconOverlay.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-windows</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 		<RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
-		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableComHosting>true</EnableComHosting>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Src/WinFileExplorerGbxAddons.Thumbnail/ComStreamWrapper.cs
+++ b/Src/WinFileExplorerGbxAddons.Thumbnail/ComStreamWrapper.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 
 namespace WinFileExplorerGbxAddons.Thumbnail;
@@ -32,7 +34,7 @@ public class ComStreamWrapper : Stream
     {
         get
         {
-            mSource.Stat(out STATSTG stat, 1);
+            mSource.Stat(out var stat, 1);
             return stat.cbSize;
         }
     }
@@ -74,6 +76,6 @@ public class ComStreamWrapper : Stream
             throw new NotImplementedException();
         }
 
-        mSource.Write(buffer, count, nint.Zero);
+        mSource.Write(buffer, count, IntPtr.Zero);
     }
 }

--- a/Src/WinFileExplorerGbxAddons.Thumbnail/GbxThumbnailProvider.cs
+++ b/Src/WinFileExplorerGbxAddons.Thumbnail/GbxThumbnailProvider.cs
@@ -3,7 +3,11 @@ using GBX.NET.Engines.Game;
 using GBX.NET.Engines.GameData;
 using GBX.NET.Imaging;
 using Microsoft.Win32;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using System;
 using System.Drawing;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 
@@ -33,7 +37,7 @@ public class GbxThumbnailProvider : IThumbnailProvider, IInitializeWithStream
         pdwAlpha = WTS_ALPHATYPE.WTSAT_ARGB;
 
         // Set phbmp to nint.Zero if the thumbnail cannot be generated
-        phbmp = nint.Zero;
+        phbmp = IntPtr.Zero;
 
         if (stream is null)
         {
@@ -156,7 +160,7 @@ public class GbxThumbnailProvider : IThumbnailProvider, IInitializeWithStream
         var regKey = Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Classes\.gbx\ShellEx\{e357fccd-a995-4576-b01f-234630154e96}");
         regKey.SetValue("", t.GUID.ToString("B").ToUpperInvariant());
         regKey.Close();
-        ShellInterop.SHChangeNotify(0x08000000, 0, nint.Zero, nint.Zero);
+        ShellInterop.SHChangeNotify(0x08000000, 0, IntPtr.Zero, IntPtr.Zero);
     }
 
     /// <remarks>This method is not testable.</remarks>
@@ -175,6 +179,6 @@ public class GbxThumbnailProvider : IThumbnailProvider, IInitializeWithStream
         regKey.DeleteValue("", false);
         regKey.Close();
 
-        ShellInterop.SHChangeNotify(0x08000000, 0, nint.Zero, nint.Zero);
+        ShellInterop.SHChangeNotify(0x08000000, 0, IntPtr.Zero, IntPtr.Zero);
     }
 }

--- a/Src/WinFileExplorerGbxAddons.Thumbnail/ShellInterop.cs
+++ b/Src/WinFileExplorerGbxAddons.Thumbnail/ShellInterop.cs
@@ -8,6 +8,6 @@ public sealed partial class ShellInterop
     {
     }
 
-    [LibraryImport("shell32.dll")]
-    internal static partial void SHChangeNotify(int eventID, uint flags, nint item1, nint item2);
+    [DllImport("shell32.dll")]
+    internal static extern void SHChangeNotify(int eventID, uint flags, nint item1, nint item2);
 }

--- a/Src/WinFileExplorerGbxAddons.Thumbnail/WinFileExplorerGbxAddons.Thumbnail.csproj
+++ b/Src/WinFileExplorerGbxAddons.Thumbnail/WinFileExplorerGbxAddons.Thumbnail.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-windows</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 		<RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
-		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableComHosting>true</EnableComHosting>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="GBX.NET" Version="1.2.1" />
 		<PackageReference Include="GBX.NET.Imaging" Version="1.1.2" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
 		<PackageReference Include="System.Drawing.Common" Version="7.0.0" />
 	</ItemGroup>
 

--- a/Tests/WinFileExplorerGbxAddons.IconOverlay.Tests/WinFileExplorerGbxAddons.IconOverlay.Tests.csproj
+++ b/Tests/WinFileExplorerGbxAddons.IconOverlay.Tests/WinFileExplorerGbxAddons.IconOverlay.Tests.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-windows</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<LangVersion>11</LangVersion>
 
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>

--- a/Tests/WinFileExplorerGbxAddons.Thumbnail.Tests/GbxThumbnailProviderTests.cs
+++ b/Tests/WinFileExplorerGbxAddons.Thumbnail.Tests/GbxThumbnailProviderTests.cs
@@ -104,13 +104,13 @@ public class GbxThumbnailProviderTests
     }
 
     [Fact]
-    public async Task GetIconBitmap_HasIconWebP_ResizeBitmap()
+    public void GetIconBitmap_HasIconWebP_ResizeBitmap()
     {
         // Arrange
         var expectedSize = 64;
         
         var collector = (CGameCtnCollector)Activator.CreateInstance(typeof(CGameCtnCollector), nonPublic: true)!;
-        collector.IconWebP = await File.ReadAllBytesAsync("icon.webp");
+        collector.IconWebP = File.ReadAllBytes("icon.webp");
 
         // Act
         var bmp = GbxThumbnailProvider.GetIconBitmap(collector, expectedSize);

--- a/Tests/WinFileExplorerGbxAddons.Thumbnail.Tests/WinFileExplorerGbxAddons.Thumbnail.Tests.csproj
+++ b/Tests/WinFileExplorerGbxAddons.Thumbnail.Tests/WinFileExplorerGbxAddons.Thumbnail.Tests.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-windows</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<LangVersion>11</LangVersion>
 
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>


### PR DESCRIPTION
As correctly mentioned on my Discord server, it is possible to not require the .net installation step with a bit different approach, so I'm testing that on this branch.

The idea is to use .NET Framework 4.8, as that is the latest version that is [preinstalled on recent Windows versions](https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies#net-framework-48) (since roughly 2018).

The assemblies should be just fine to compile, but the installers are not compatible yet.